### PR TITLE
Se agregó un comentario sobre la funcionalidad.

### DIFF
--- a/src/TP3/ej4/Auto.java
+++ b/src/TP3/ej4/Auto.java
@@ -23,10 +23,10 @@ public class Auto extends Vehiculo implements Runnable {
             if (this.litrosRestantes > 0) {
                 this.recorrerKm((int) (Math.random() * 20));
             } else {
+                //En caso de que no se tenga nafta y ya no se haya podido cargar se mostrará este cartel y se terminará el bucle.
                 System.out.println(Thread.currentThread().getName() + " se detuvo, no tiene nafta en su tanque y no hay disponible en el surtidor.");
                 seguir = false;
             }
-
         }
     }
 }


### PR DESCRIPTION
Se agregó una nueva funcionalidad sobre que pasaría si el auto no tiene nafta y el surtidor ya no puede cargarle.
El escenario es el siguiente: El auto se queda sin nafta, va a cargar, el surtidor no puede cargarle ya que no tiene los litros necesarios, entonces el surtidor no le actualiza los litros al auto, en la próxima iteración del bucle, el auto no va a tener nafta entonces no se puede mover si no tiene cómo, además ya se sabe que el surtidor no le puede cargar, entonces se decide terminar con la ejecución del auto para que no spamee mensajes del tipo "no se puede cargar". 